### PR TITLE
Move links to new DNS & Upload some more SQL Dumps

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom01-08122021-2105-tempoverworld.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom01-08122021-2105-tempoverworld.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -97,7 +97,52 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/OPS_TotalFreedom-Freedom1-CoreProtect-UNIX-TempWorld-08122021-2105.sql"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/OPS_TotalFreedom-Freedom1-CoreProtect-UNIX-TempWorld-08122021-2105.sql"
+                    >Click Here</a
+                  >
+                </td>
+              </tr>              
+              <tr>
+                <td colspan="5"><b>August 2021</b></td>
+              </tr>
+              <tr>
+                <td rowspan="1">Freedom-02</td>
+                <td>CoreProtect Database Dump</td>
+                <td>19:40</td>
+                <td>28th August 2021</td>
+                <td>
+                  <a
+                    class="purple-text text-lighten-1"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/OPS_TotalFreedom-Freedom2-CoreProtect-28082021-1940.sql"
+                    >Click Here</a
+                  >
+                </td>
+              </tr>
+              <tr>
+                <td colspan="5"><b>June 2021</b></td>
+              </tr>
+              <tr>
+                <td rowspan="1">DEV-Freedom-02</td>
+                <td>CoreProtect Database Dump</td>
+                <td>20:04</td>
+                <td>27th June 2021</td>
+                <td>
+                  <a
+                    class="purple-text text-lighten-1"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/DEV_TotalFreedom-Freedom2-CoreProtect-27062021-2004.sql"
+                    >Click Here</a
+                  >
+                </td>
+              </tr>
+              <tr>
+                <td rowspan="1">Freedom-02</td>
+                <td>CoreProtect Database Dump</td>
+                <td>18:00</td>
+                <td>26th June 2021</td>
+                <td>
+                  <a
+                    class="purple-text text-lighten-1"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/OPS_TotalFreedom-Freedom2-CoreProtect-26062021-1800.sql"
                     >Click Here</a
                   >
                 </td>
@@ -113,7 +158,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mbserver-29052021-2210-world.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mbserver-29052021-2210-world.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -125,7 +170,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mbserver-29052021-2210-world_nether.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mbserver-29052021-2210-world_nether.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -137,7 +182,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mbserver-29052021-2210-world_the_end.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mbserver-29052021-2210-world_the_end.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -149,7 +194,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mbserver-29052021-2210-mapbig.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mbserver-29052021-2210-mapbig.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -161,7 +206,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mbserver-29052021-2210-mapbig_old.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mbserver-29052021-2210-mapbig_old.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -174,7 +219,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mbarchive-28052021-1500-world.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mbarchive-28052021-1500-world.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -186,7 +231,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mbarchive-28052021-1500-world_the_end.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mbarchive-28052021-1500-world_the_end.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -199,7 +244,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/smp-world_the_end-04052021-1430.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/smp-world_the_end-04052021-1430.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -211,7 +256,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/smp-world_nether-04052021-1430.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/smp-world_nether-04052021-1430.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -223,7 +268,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/smp-world-04052021-1430.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/smp-world-04052021-1430.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -259,7 +304,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/Freedom-02-CoreProtectDB-13022021-0017.sql"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/Freedom-02-CoreProtectDB-13022021-0017.sql"
                     >Click Here</a
                   >
                 </td>
@@ -275,7 +320,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-world_the_end.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-world_the_end.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -287,7 +332,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-flatlands.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-flatlands.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -299,7 +344,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/Freedom-02-CoreProtectdB-01012021-2029.sql"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/Freedom-02-CoreProtectdB-01012021-2029.sql"
                     >Click Here</a
                   >
                 </td>
@@ -311,7 +356,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-adminworld.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-adminworld.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -323,7 +368,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-hubworld.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-hubworld.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -335,7 +380,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-masterbuilderworld.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-masterbuilderworld.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -347,7 +392,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-world.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-02-23012021-1413-world.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -360,7 +405,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-beta-100121-2215-world_end.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-beta-100121-2215-world_end.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -372,7 +417,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-beta-100121-2215-world_nether.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-beta-100121-2215-world_nether.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -384,7 +429,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-beta-100121-2215-world.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-beta-100121-2215-world.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -397,7 +442,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-02-world_the_end-01012021-1816.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-02-world_the_end-01012021-1816.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -409,7 +454,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-02-flatlands-01012021-1816.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-02-flatlands-01012021-1816.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -421,7 +466,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/Freedom-02-CoreProtectdB-01012021-2029.sql"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/Freedom-02-CoreProtectdB-01012021-2029.sql"
                     >Click Here</a
                   >
                 </td>
@@ -433,7 +478,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/freedom-02-world-01012021-1816.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/freedom-02-world-01012021-1816.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -449,7 +494,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/smp-world-22112020-2150.zip"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/smp-world-22112020-2150.zip"
                     >Click Here</a
                   >
                 </td>
@@ -461,7 +506,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/smp-world_nether-22112020-2019.zip"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/smp-world_nether-22112020-2019.zip"
                     >Click Here</a
                   >
                 </td>
@@ -473,7 +518,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/smp-world_the_end-22112020-2014.zip"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/smp-world_the_end-22112020-2014.zip"
                     >Click Here</a
                   >
                 </td>
@@ -485,7 +530,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/smp-spawn-22112020-2013.zip"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/smp-spawn-22112020-2013.zip"
                     >Click Here</a
                   >
                 </td>
@@ -501,7 +546,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/hubworld-30102020-1933.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/hubworld-30102020-1933.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -513,7 +558,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/flatlands-30102020-1933.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/flatlands-30102020-1933.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -525,7 +570,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/staffworld-30102020-1933.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/staffworld-30102020-1933.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -537,7 +582,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/staffworld-30102020-1933.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/staffworld-30102020-1933.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -549,7 +594,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/plotworld-30102020-1933.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/plotworld-30102020-1933.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -561,7 +606,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/nether-30102020-1933.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/nether-30102020-1933.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -573,7 +618,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/masterbuilderworld-30102020-1933.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/masterbuilderworld-30102020-1933.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -585,7 +630,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mainworld-30102020-1933.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mainworld-30102020-1933.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -598,7 +643,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/flatlands-29102020-1153.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/flatlands-29102020-1153.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -610,7 +655,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mainworld-29102020-1053.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mainworld-29102020-1053.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -622,7 +667,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mainworld-29102020-1047.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mainworld-29102020-1047.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -634,7 +679,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/nether-29102020-1047.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/nether-29102020-1047.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -647,7 +692,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/flatlands-28102020-2330.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/flatlands-28102020-2330.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -660,7 +705,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/flatlands-25102020-1540.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/flatlands-25102020-1540.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -672,7 +717,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/mainworld-25102020-1540.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/mainworld-25102020-1540.tgz"
                     >Click Here</a
                   >
                 </td>
@@ -684,7 +729,7 @@
                 <td>
                   <a
                     class="purple-text text-lighten-1"
-                    href="https://f000.backblazeb2.com/file/tf-downloads/world-download-tool/tfworld-25102020-1400.tgz"
+                    href="https://f000-backblazeb2.totalfreedom.me/file/tf-downloads/world-download-tool/tfworld-25102020-1400.tgz"
                     >Click Here</a
                   >
                 </td>


### PR DESCRIPTION
Moved the links to now be powered via our Cloudflare CDN to improve global cache but also to reduce our bandwidth costs.

Added a larger SQLDump of the CoreProtect Database for Freedom-02, and a random one from DEV-Freedom-02.